### PR TITLE
Defer `update_cache: yes` to `apt` task

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,12 +6,12 @@
 - name: Add Cloudflare PPA
   apt_repository:
     repo: 'deb http://pkg.cloudflare.com/ xenial main'
-    update_cache: yes
 
 - name: Install CFCA
   apt:
     name: cfca
     state: "{{ cfca_package_state }}"
+    update_cache: yes
     force: yes
 
 - name: Create directoriy and set permission


### PR DESCRIPTION
Because `apt_repository` task skips `apt-get update` if repo is already added