### PR TITLE
Deprecate `key_type` and `key_size`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,6 @@ wordpress_sites:
         - example.com
         - '*.example.com'
         - '*.another-example.com'
-      # Key size in bits to use for the generated key pair (Acceptable sizes: rsa: 2048|3072|4096, ecdsa: 256|384|521)
-      # Default: 256
-      key_size: 3072
-      # Type of key pair to generate, either RSA or ECDSA. (rsa|ecdsa)
-      # Default: ecdsa
-      key_type: rsa
 ```
 
 ## Hacking Trellis' Playbook
@@ -167,6 +161,24 @@ Encrypt your Cloudflare Origin CA Key in `group_vars/<environment>/vault.yml`. S
 > --- Cloudflare Support
 
 Cloudflare Origin CA doesn't support OCSP stapling. Disable OCSP stapling for all sites using Cloudflare Origin CA. See [role variables](#role-variables).
+
+### `key_type` is deprecated. Please remove it from `example.com`
+
+To avoid misconfiguration, the `key_type` (ECDSA or RSA) and `key_size` (bits) options are deprecated. Since v0.8, this role generates 521-bit ECDSA keys only.
+
+If you had previsously generated CA certificates with other configurations:
+1. remove the CA certificates from servers
+1. revoke the CA certificates via Cloudflare dashboard
+1. re-provision the servers
+
+### `key_size` is deprecated. Please remove it from `example.com`
+
+To avoid misconfiguration, the `key_type` (ECDSA or RSA) and `key_size` (bits) options are deprecated. Since v0.8, this role generates 521-bit ECDSA keys only.
+
+If you had previsously generated CA certificates with other configurations:
+1. remove the CA certificates from servers
+1. revoke the CA certificates via Cloudflare dashboard
+1. re-provision the servers
 
 ### Nginx directories not included
 
@@ -215,16 +227,21 @@ To get certificates from [Let's Encrypt](https://letsencrypt.org/), you have to 
 
 See [Introducing Cloudflare Origin CA](https://blog.cloudflare.com/cloudflare-ca-encryption-origin/#whataretheincrementalbenefitsoforigincaoverpubliccertificates) on Cloudflare blog.
 
-### Why use 256-bit ECDSA key as default?
+### Why only 521-bit ECDSA keys allowed?
 
 >I assume you would like to setup [Authenticated Origin Pulls](https://support.cloudflare.com/hc/en-us/articles/204899617-Authenticated-Origin-Pulls) with Cloudflare. I would recommend ECDSA, as elliptic curves provide the same security with less computational overhead.
 >
 >Find out more about [ECDSA: The digital signature algorithm of a better internet](https://blog.cloudflare.com/ecdsa-the-digital-signature-algorithm-of-a-better-internet/)
 >The above article also mentioned that: According to the [ECRYPT II recommendations](http://www.keylength.com/en/3/) on key length, a 256-bit elliptic curve key provides as much protection as a 3,248-bit asymmetric key.Typical RSA keys in website certificates are 2048-bits. So, I think going with 256-bits ECDSA will be a good choice.
 >
-> --- Cloudflare Support
+> --- Cloudflare Support, September 2017
 
-If you insist to use RSA keys, make sure you set `key_size` to at least `2048`.
+To avoid misconfiguration, the `key_type` (ECDSA or RSA) and `key_size` (bits) options are deprecated. Since v0.8, this role generates 521-bit ECDSA keys only.
+
+If you had previsously generated CA certificates with other configurations:
+1. remove the CA certificates from servers
+1. revoke the CA certificates via Cloudflare dashboard
+1. re-provision the servers
 
 ### Why Cloudflare Origin CA key is logged even `cloudflare_origin_ca_no_log` is `true`?
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,6 @@ site_uses_cloudflare_origin_ca: "{{ ssl_enabled and item.value.ssl.provider | de
 site_cfca_config_default:
   days: 5475
   hostnames: "{{ site_hosts | union(multisite_subdomains_wildcards) }}"
-  key_size: 256
-  key_type: ecdsa
 
 site_cfca_config: "{{ site_cfca_config_default | combine(item.value.cloudflare_origin_ca | default({})) }}"
 

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -4,8 +4,8 @@
     -certificate-out {{ item.key | quote }}.pem \
     -days {{ site_cfca_config.days }} \
     -hostnames {{ site_cfca_config.hostnames | join(',') }} \
-    -key-size {{ site_cfca_config.key_size }} \
-    -key-type {{ site_cfca_config.key_type }}"
+    -key-size 521 \
+    -key-type ecdsa"
   args:
     chdir: "{{ nginx_ssl_path }}/cloudflare-origin-ca"
     creates: "{{ item.key }}.*"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,17 +4,37 @@
     msg: No site is using Cloudflare Origin CA
   when: sites_using_cloudflare_origin_ca | count < 1
 
-- name: Fail if vault_cloudflare_origin_ca_key is not defined
+- name: Fail if `vault_cloudflare_origin_ca_key` is not defined
   fail:
-    msg: vault_cloudflare_origin_ca_key is not defined
+    msg: "`vault_cloudflare_origin_ca_key` is not defined"
   when: vault_cloudflare_origin_ca_key is not defined
 
 - name: Fail if OCSP stapling is enabled
   fail:
-    msg: "{{ item.key }} is using Cloudflare Origin CA but OCSP stapling is enabled"
+    msg: "`{{ item.key }}` is using Cloudflare Origin CA but OCSP stapling is enabled"
   when:
     - site_uses_cloudflare_origin_ca | bool
     - item.value.ssl.stapling_enabled | default(true)
+  with_dict: "{{ wordpress_sites }}"
+
+- name: Fail if key_type  is defined
+  fail:
+    msg: |
+      `key_type` is deprecated. Please remove it from {{ item.key }}
+      See: https://github.com/TypistTech/trellis-cloudflare-origin-ca/pull/53"
+  when:
+    - site_uses_cloudflare_origin_ca | bool
+    - site_cfca_config.key_type is defined
+  with_dict: "{{ wordpress_sites }}"
+
+- name: Fail if key_size is defined
+  fail:
+    msg: |
+      `key_size` is deprecated. Please remove it from {{ item.key }}
+      See: https://github.com/TypistTech/trellis-cloudflare-origin-ca/pull/53
+  when:
+    - site_uses_cloudflare_origin_ca | bool
+    - site_cfca_config.key_size is defined
   with_dict: "{{ wordpress_sites }}"
 
 - include: setup.yml


### PR DESCRIPTION
To avoid misconfiguration, the `key_type` (ECDSA or RSA) and `key_size` (bits) options are deprecated. Since this PR, this role generates 521-bit ECDSA keys only.

If you had previsously generated CA certificates with other configurations:
1. remove the CA certificates from servers
1. revoke the CA certificates via Cloudflare dashboard
1. re-provision the servers

close #42 