### PR TITLE
Add support for Authenticated Origin Pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ wordpress_sites:
         - example.com
         - '*.example.com'
         - '*.another-example.com'
+      # Enable Authenticated Origin Pulls support. Requires SSL/TLS encryption mode set to Full or higher and Authenticated Origin Pulls must be turned on.
+      # Default: false
+      # https://developers.cloudflare.com/ssl/origin-configuration/authenticated-origin-pull/
+      authenticated_origin_pulls_enabled: true
 ```
 
 ---

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 sites_using_cloudflare_origin_ca: "[{% for name, site in wordpress_sites.items() | list if site.ssl.enabled and site.ssl.provider | default('manual') == 'cloudflare-origin-ca' %}'{{ name }}',{% endfor %}]"
 site_uses_cloudflare_origin_ca: "{{ ssl_enabled and item.value.ssl.provider | default('manual') == 'cloudflare-origin-ca' }}"
+site_uses_cloudflare_authenticated_origin_pulls: "{{site_uses_cloudflare_origin_ca and item.value.cloudflare_origin_ca.authenticated_origin_pulls_enabled | default(false) }}"
 
 site_cfca_config_default:
   days: 5475

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -14,3 +14,11 @@
   no_log: "{{ cloudflare_origin_ca_no_log }}"
   when: site_uses_cloudflare_origin_ca | bool
   with_dict: "{{ wordpress_sites }}"
+
+- name: Fetch Cloudflare Authenticated Origin Pull CA
+  command: "curl -o {{ nginx_ssl_path }}/authenticated_origin_pull_ca.pem https://developers.cloudflare.com/ssl/static/authenticated_origin_pull_ca.pem"
+  args:
+    chdir: "{{ nginx_ssl_path }}"
+    creates: "authenticated_origin_pull_ca.pem"
+  when: site_uses_cloudflare_authenticated_origin_pulls | bool
+  with_dict: "{{ wordpress_sites }}"

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -15,3 +15,12 @@
   when: site_uses_cloudflare_origin_ca | bool
   with_dict: "{{ wordpress_sites }}"
   notify: reload nginx
+
+- name: Template Nginx SSL client directives out to includes.d
+  template:
+    src: cloudflare-authenticated-origin-pulls.conf.j2
+    dest: "{{ nginx_path }}/includes.d/{{ item.key }}/cloudflare-authenticated-origin-pulls.conf"
+    mode: '0600'
+  when: site_uses_cloudflare_authenticated_origin_pulls | bool
+  with_dict: "{{ wordpress_sites }}"
+  notify: reload nginx

--- a/templates/cloudflare-authenticated-origin-pulls.conf.j2
+++ b/templates/cloudflare-authenticated-origin-pulls.conf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+# Cloudflare Authenticated Origin Pulls
+
+ssl_client_certificate {{ nginx_ssl_path }}/authenticated_origin_pull_ca.pem;
+ssl_verify_client on;


### PR DESCRIPTION
Adds the option to [set up Authenticated Origin Pulls](https://developers.cloudflare.com/ssl/origin-configuration/authenticated-origin-pull/set-up/) configuration for Cloudflare.

This feature adds a new variable named `authenticated_origin_pulls_enabled` to enable support:
```yaml
wordpress_sites:
  example.com:
    # ...
    cloudflare_origin_ca:
      authenticated_origin_pulls_enabled: true